### PR TITLE
fixed/prevented error when bullet preset width is set too short

### DIFF
--- a/src/components/Bullets/Bullet.js
+++ b/src/components/Bullets/Bullet.js
@@ -16,7 +16,7 @@ function Bullet({
   const [loading, setLoading] = useState(false);
   const [optimStatus, setOptimStatus] = useState(STATUS.NOT_OPT);
   const [rendering, setBulletRendering] = useState({ textLines: [""] });
-  const widthPxAdjusted = widthPx + 0.55;
+  const widthPxAdjusted = widthPx < 75 ? 75 : widthPx + 0.55;
 
   function getTextWidth(txt, canvas) {
     const context = canvas.getContext("2d");


### PR DESCRIPTION
for some reason, when the bullet width is set too short, the output bullet remains short even if the bullet width is set to something
 longer again. this will be guaranteed to happen if you delete the characters in the width input window all the way when you are
 entering in a new width. I was not able to find the root cause, but was able to prevent the issue from happening entirely by manually
 enforcing a minimum pixel width of 75 pixels.